### PR TITLE
Adding `static` keyword to all functions.

### DIFF
--- a/Validate/FI.php
+++ b/Validate/FI.php
@@ -83,7 +83,7 @@ class Validate_FI
      * @access      public
      * @return      bool    true if postal code is valid, false otherwise
      */
-    function postalCode($number, $strong=false)
+    static function postalCode($number, $strong=false)
     {
         return (bool) preg_match("/^(FI-)?[0-9]{5}$/", $number);
     }
@@ -117,7 +117,7 @@ class Validate_FI
      * @access      public
      * @return      bool    true if telephone number is valid, false otherwise
      */
-    function phoneNumber($number)
+    static function phoneNumber($number)
     {
         $number = str_replace(Array('(', ')', '-', '+', '.', ' '), '', $number);
         return (bool) preg_match("/^[0-9]{3,20}$/", $number);
@@ -156,7 +156,7 @@ class Validate_FI
      * @return      bool    true if license plate number is valid, false otherwise
      * @link        http://www.ake.fi/AKE/Rekisterointi/Suomen_rekisterikilvet/
      */
-    function carLicensePlate($number)
+    static function carLicensePlate($number)
     {
         // diplomat licence plate
         if (preg_match("/^CD-[1-9]{1}[0-9]{0,3}$/", $number)) {
@@ -205,7 +205,7 @@ class Validate_FI
      * @return      bool    true if license plate number is valid, false otherwise
      * @link        http://www.ake.fi/AKE/Rekisterointi/Suomen_rekisterikilvet/
      */
-    function bikeLicensePlate($number)
+    static function bikeLicensePlate($number)
     {
         $reg = "/^[A-ZÅÄÖ]{2,3}(\n)?[1-9]{1}[0-9]{0,2}$/";
         return (bool) preg_match($reg, $number);
@@ -259,7 +259,7 @@ class Validate_FI
      *                      in array if PIN is valid, false otherwise
      * @link        http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#hetu1
      */
-    function pin($number, $info = false)
+    static function pin($number, $info = false)
     {
         $regs           = '';
         $pin            = strtoupper($number);
@@ -317,7 +317,7 @@ class Validate_FI
      * @return      bool    true if FINUID is valid, false otherwise
      * @link        http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#satu
      */
-    function finuid($number)
+    static function finuid($number)
     {
         $regs           = '';
         $number         = strtoupper($number);
@@ -364,7 +364,7 @@ class Validate_FI
      * @return      bool    true if Business ID is valid, false otherwise
      * @link        http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#y-tunnus2
      */
-    function businessId($number)
+    static function businessId($number)
     {
         if (preg_match("/^[0-9]{6,7}-[0-9]{1}$/", $number)) {
             list($num, $control) = preg_split('[-]', $number);
@@ -422,7 +422,7 @@ class Validate_FI
      * @see         Validate_FI::businessId()
      * @link        http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#alv-numero
      */
-    function partyId($number)
+    static function partyId($number)
     {
         if (preg_match("/^[0-9]{12,17}$/", $number)) {
             $countryCode = substr($number, 0, 4);
@@ -469,7 +469,7 @@ class Validate_FI
      * @see         Validate_FI::businessId()
      * @link        http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#alv-numero
      */
-    function vatNumber($number)
+    static function vatNumber($number)
     {
         $countryCode = substr($number, 0, 2);
         $controlNum  = substr($number, -1, 1);
@@ -514,7 +514,7 @@ class Validate_FI
      * @link   http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#pankkitili
      * @link   http://www.pankkiyhdistys.fi/sisalto/upload/pdf/tilinrorakenne.pdf
      */
-    function bankAccount($number)
+    static function bankAccount($number)
     {
         if (preg_match("/^[0-9]{6}-[0-9]{2,8}$/", $number)) {
             // Bank groups are identified by the first digit
@@ -571,7 +571,7 @@ class Validate_FI
      * @return      bool    true if reference number is valid, false otherwise
      * @link        http://tarkistusmerkit.teppovuori.fi/tarkmerk.htm#viitenumero
      */
-    function refNum($number)
+    static function refNum($number)
     {
         // Remove non-numeric characters from $refnum. Only 4-20 digit number.
         $refnum = preg_replace('/[^0-9]+/', '', $number);
@@ -636,7 +636,7 @@ class Validate_FI
      * @access      public
      * @return      bool    true if credit card number is valid, false otherwise
      */
-    function creditCard($number)
+    static function creditCard($number)
     {
         // Remove non-numeric characters from $number 
         $number = preg_replace('/[^0-9]+/', '', $number);
@@ -658,7 +658,7 @@ class Validate_FI
      * @return      bool    true if number is valid, false otherwise
      * @link        http://en.wikipedia.org/wiki/Luhn_algorithm
      */
-    function _mod10($number)
+    static function _mod10($number)
     {
         // Double every second digit started at the right
         $doubledNumber = '';

--- a/tests/do_not_ignore_any_error.php
+++ b/tests/do_not_ignore_any_error.php
@@ -1,0 +1,32 @@
+<?php
+
+function do_not_ignore_any_error($errno, $errstr, $errfile, $errline)  {
+	$error_names = array(
+		1 => 'E_ERROR',
+		2 => 'E_WARNING',
+		4 => 'E_PARSE',
+		8 => 'E_NOTICE',
+		16 => 'E_CORE_ERROR',
+		32 => 'E_CORE_WARNING',
+		64 => 'E_COMPILE_ERROR',
+		128 => 'E_COMPILE_WARNING',
+		256 => 'E_USER_ERROR',
+		512 => 'E_USER_WARNING',
+		1024 => 'E_USER_NOTICE',
+		2048 => 'E_STRICT',
+		4096 => 'E_RECOVERABLE_ERROR',
+		8192 => 'E_DEPRECATED',
+		16384 => 'E_USER_DEPRECATED',
+	);
+	$errorname = $error_names[$errno];
+
+	if ($errno !== E_USER_ERROR) {
+		trigger_error("PHP Error $errorname ($errno): $errstr (at $errfile:$errline)", E_USER_ERROR);
+	}
+
+	return false;
+}
+
+set_error_handler("do_not_ignore_any_error", E_ALL | E_STRICT);
+
+?>

--- a/tests/validate_FI_bankAccount.phpt
+++ b/tests/validate_FI_bankAccount.phpt
@@ -4,6 +4,7 @@ validate_FI_bankAccount.phpt: Unit tests for bankAccount method 'Validate/FI.php
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_bikeLicensePlate.phpt
+++ b/tests/validate_FI_bikeLicensePlate.phpt
@@ -4,6 +4,7 @@ validate_FI_bikeLicensePlate.phpt: Unit tests for bikeLicensePlate method 'Valid
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_businessId.phpt
+++ b/tests/validate_FI_businessId.phpt
@@ -4,6 +4,7 @@ validate_FI_businessId.phpt: Unit tests for businessId method 'Validate/FI.php'
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_carLicensePlate.phpt
+++ b/tests/validate_FI_carLicensePlate.phpt
@@ -4,6 +4,7 @@ validate_FI_carLicensePlate.phpt: Unit tests for carLicensePlate method 'Validat
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_creditCard.phpt
+++ b/tests/validate_FI_creditCard.phpt
@@ -4,6 +4,7 @@ validate_FI_creditCard.phpt: Unit tests for creditCard method 'Validate/FI.php'
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_finuid.phpt
+++ b/tests/validate_FI_finuid.phpt
@@ -4,6 +4,7 @@ validate_FI_finuid.phpt: Unit tests for finuid method 'Validate/FI.php'
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_partyId.phpt
+++ b/tests/validate_FI_partyId.phpt
@@ -4,6 +4,7 @@ validate_FI_partyId.phpt: Unit tests for partyId method 'Validate/FI.php'
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_phoneNumber.phpt
+++ b/tests/validate_FI_phoneNumber.phpt
@@ -4,6 +4,7 @@ validate_FI_phoneNumber.phpt: Unit tests for phoneNumber method 'Validate/FI.php
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_pin.phpt
+++ b/tests/validate_FI_pin.phpt
@@ -4,6 +4,7 @@ validate_FI_pin.phpt: Unit tests for pin method 'Validate/FI.php'
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_postalCode.phpt
+++ b/tests/validate_FI_postalCode.phpt
@@ -4,6 +4,7 @@ validate_FI_postalCode.phpt: Unit tests for postalCode method 'Validate/FI.php'
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_refNum.phpt
+++ b/tests/validate_FI_refNum.phpt
@@ -4,6 +4,7 @@ validate_FI_refNum.phpt: Unit tests for refNum method 'Validate/FI.php'
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';

--- a/tests/validate_FI_vatNumber.phpt
+++ b/tests/validate_FI_vatNumber.phpt
@@ -4,6 +4,7 @@ validate_FI_vatNumber.phpt: Unit tests for vatNumber method 'Validate/FI.php'
 <?php
 // $Id$
 // Validate test script
+require_once dirname(__FILE__) . '/do_not_ignore_any_error.php';
 $noYes = array('NO', 'YES');
 if (is_file(dirname(__FILE__) . '/../Validate/FI.php')) {
     require_once dirname(__FILE__) . '/../Validate/FI.php';


### PR DESCRIPTION
Calling a class method without a class instance is only possible if the
method has been declared as static. Otherwise, PHP will generate an
E_STRICT error. This error, however, is non-fatal, and will not stop the
execution.

This commit adds an error handler that triggers a fatal error even for
non-fatal ones. After adding this error handler, all unit tests started
failing.

The fix is trivial: add static keyword to static methods.
